### PR TITLE
Update labeler action rules

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,5 +1,9 @@
 repo:
-  - any: ['.github/**/*', '.gitignore', 'README.*', '*.example', '**/.example', 'Makefile']
+  - '.github/**/*'
+  - '.gitignore'
+  - 'README.*'
+  - '**/.example'
+  - 'Makefile'
 
 ansible:
   - 'ansible/**/*'
@@ -14,4 +18,5 @@ caddy:
   - 'images/caddy/**/*'
 
 docker:
-  - any: ['docker-compose.*', '**/Dockerfile']
+  - 'docker-compose.*'
+  - '**/Dockerfile'


### PR DESCRIPTION
`any` doesn't work the way I had assumed. It needs to match all globs in any file, not any glob in all files