### PR TITLE
Integrate Terraform with GitHub secrets

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -13,27 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       tree_sha: ${{ steps.tree_sha.outputs.value }}
-      deployer_username: ${{ steps.tf_deployer_username.outputs.value }}
     steps:
       - uses: actions/checkout@v3
       - id: tree_sha
         run: echo "::set-output name=value::$(git rev-parse HEAD:)"
-
-  terraform_outputs:
-    name: Fetch terraform outputs
-    runs-on: ubuntu-latest
-    outputs:
-      primary_ip: ${{ steps.tfc.outputs.primary_ip }}
-      deployer_username: ${{ steps.tfc.outputs.deployer_username }}
-    steps:
-      - uses: actions/checkout@v3
-      - id: tfc
-        uses: ./.github/actions/terraform-cloud-outputs
-        with:
-          token: ${{ secrets.TERRAFORM_CLOUD_TOKEN }}
-          org: ${{ secrets.TERRAFORM_CLOUD_ORG }}
-          workspace: ${{ secrets.TERRAFORM_CLOUD_WORKSPACE }}
-          variables: deployer_username, primary_ip
 
   clean:
     name: Delete old packages
@@ -96,7 +79,6 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - calculated_values
-      - terraform_outputs
       - build
     if: startsWith(github.ref, 'refs/heads/deploy')
     env:
@@ -126,9 +108,9 @@ jobs:
 
       - uses: ./.github/actions/docker-compose-deploy
         with:
-          ssh_user: ${{ needs.terraform_outputs.outputs.deployer_username }}
-          ssh_host: ${{ needs.terraform_outputs.outputs.primary_ip }}
-          ssh_key: ${{ secrets.SSH_KEY }}
+          ssh_user: ${{ secrets.DEPLOYER_USERNAME }}
+          ssh_host: ${{ secrets.PRIMARY_INSTANCE_IP }}
+          ssh_key: ${{ secrets.DEPLOYER_SSH_PRIVATE_KEY }}
           stack_name: vault
           docker_registry: ghcr.io
           docker_username: ${{ github.repository_owner }}

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -40,6 +40,47 @@ provider "registry.terraform.io/hashicorp/template" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/tls" {
+  version = "3.4.0"
+  hashes = [
+    "h1:oyllIA9rNGCFtClSyBitUIzCXdnKtspVepdsvpLlfys=",
+    "zh:2442a0df0cfb550b8eba9b2af39ac06f54b62447eb369ecc6b1c29f739b33bbb",
+    "zh:3ebb82cacb677a099de55f844f0d02886bc804b1a2b94441bc40fabcb64d2a38",
+    "zh:436125c2a7e66bc62a4a7c68bdca694f071d7aa894e8637dc83f4a68fe322546",
+    "zh:5f03db9f1d77e8274ff4750ae32d5c16c42b862b06bcb0683e4d733c8db922e4",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:8190142ae8a539ab34193b7e75da0fa04035d1dcd8af8be94df1eafeeffb44b6",
+    "zh:8cdc7cd9221e27c189e5beaf78462fce4c2edb081f415a1eafc6da2949de31e2",
+    "zh:a5de0f7f5d63c59ebf61d3c1d94040f410665ff0aa04f66674efe24b39a11f94",
+    "zh:a9fce48db3c140cc3e06f8a3c7ef4d36735e457e7660442d6d5dcd2b0781adc3",
+    "zh:beb92de584c790c7c7f047e45ccd22b6ee3263c7b5a91ae4d6882ae6e7700570",
+    "zh:f373f8cc52846fb513f44f468d885f722ca4dc22af9ff1942368cafd16b796b3",
+    "zh:f69627fd6e5a920b17ff423cdbad2715078ca6d13146dc67668795582ab43748",
+  ]
+}
+
+provider "registry.terraform.io/integrations/github" {
+  version     = "4.26.1"
+  constraints = "~> 4.0"
+  hashes = [
+    "h1:7in21iUvEJxqkMBojPKQcR8pIbL5I+adC+pMwYH3YDo=",
+    "zh:106aec70ccc00955282dbb07fc5daae9231db127bb6912c460ab7bbcc83e2497",
+    "zh:2b9c8ded414a7815ffe79774d428ea12c68ef1fb7b67aa95a9917c5f0e487738",
+    "zh:6494db79f68f1f220cffcfdf18ce1943c098a643eb610dc6cc8b27f0277069ad",
+    "zh:705a31d53d3417bdea1cb765fd84e9e958325de0ddd01b43a0c3175734d31098",
+    "zh:76389591b417d8035d7aa3b9f81883b87c8efa767fcd4968abfb30a2641df1cc",
+    "zh:7dcb526e515296080f724c3b2bdeb04739a46034ea382a0bd6210436d1904203",
+    "zh:9878bf61cca2439f32dc290245137b33cb9ca556e68e4bda36899f579e57b3f9",
+    "zh:9c1aabe76001fca0a16550720787b6635044846787152fb250304c369c415a8e",
+    "zh:bd22b65a74471589498298c5f3a5e4403b0d4be0812c257195eccc70df2dd561",
+    "zh:d9f36f76ce57c360bfd1d430712a4c7457fcd72aefc8914a49ba135cffd06615",
+    "zh:e7d2718706c904faaa935e8112fc1b4750109d070c49feaa2b4df03ebe866428",
+    "zh:f3eb43d54acd4c8dc0135a45621c74b58676295ac9c640ab9264f160ea0ba614",
+    "zh:f59490c68239bf1a3e3580be61378d605ed02b7023fb073da1ade7fa784dc674",
+    "zh:fdf6007b3180ccbdc9875c426f40d5ae7933f6a7b617aa2e0107226074946ea5",
+  ]
+}
+
 provider "registry.terraform.io/oracle/oci" {
   version     = "4.77.0"
   constraints = "~> 4.77"

--- a/terraform/github.tf
+++ b/terraform/github.tf
@@ -1,0 +1,17 @@
+resource "github_actions_secret" "deployer_ssh_private_key" {
+  repository       = var.github_repository
+  secret_name      = "DEPLOYER_SSH_PRIVATE_KEY"
+  plaintext_value  = tls_private_key.deployer.private_key_pem
+}
+
+resource "github_actions_secret" "deployer_username" {
+  repository       = var.github_repository
+  secret_name      = "DEPLOYER_USERNAME"
+  plaintext_value  = tls_private_key.deployer.private_key_pem
+}
+
+resource "github_actions_secret" "primary_instance_ip" {
+  repository       = var.github_repository
+  secret_name      = "PRIMARY_INSTANCE_IP"
+  plaintext_value  = tls_private_key.deployer.private_key_pem
+}

--- a/terraform/github.tf
+++ b/terraform/github.tf
@@ -1,17 +1,17 @@
 resource "github_actions_secret" "deployer_ssh_private_key" {
-  repository       = var.github_repository
-  secret_name      = "DEPLOYER_SSH_PRIVATE_KEY"
-  plaintext_value  = tls_private_key.deployer.private_key_pem
+  repository      = var.github_repository
+  secret_name     = "DEPLOYER_SSH_PRIVATE_KEY"
+  plaintext_value = tls_private_key.deployer.private_key_pem
 }
 
 resource "github_actions_secret" "deployer_username" {
-  repository       = var.github_repository
-  secret_name      = "DEPLOYER_USERNAME"
-  plaintext_value  = tls_private_key.deployer.private_key_pem
+  repository      = var.github_repository
+  secret_name     = "DEPLOYER_USERNAME"
+  plaintext_value = tls_private_key.deployer.private_key_pem
 }
 
 resource "github_actions_secret" "primary_instance_ip" {
-  repository       = var.github_repository
-  secret_name      = "PRIMARY_INSTANCE_IP"
-  plaintext_value  = tls_private_key.deployer.private_key_pem
+  repository      = var.github_repository
+  secret_name     = "PRIMARY_INSTANCE_IP"
+  plaintext_value = tls_private_key.deployer.private_key_pem
 }

--- a/terraform/instances.tf
+++ b/terraform/instances.tf
@@ -35,7 +35,7 @@ resource "oci_core_instance" "instances" {
   }
 
   metadata = {
-    ssh_authorized_keys = var.admin_public_key
+    ssh_authorized_keys = var.admin_ssh_public_key
     user_data           = base64encode(data.template_file.cloud-init.rendered)
   }
 
@@ -56,8 +56,8 @@ data "template_file" "cloud-init" {
   template = file("cloud-init.tpl.yml")
   vars = {
     deployer_username   = var.deployer_username
-    deployer_public_key = var.deployer_public_key
+    deployer_public_key = tls_private_key.deployer.public_key_openssh
     admin_username      = var.admin_username
-    admin_public_key    = var.admin_public_key
+    admin_public_key    = var.admin_ssh_public_key
   }
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -37,6 +37,11 @@ provider "cloudflare" {
 }
 
 
+# SSH Key for deployer user
+resource "tls_private_key" "deployer" {
+  algorithm = "ED25519"
+}
+
 output "instance_ips" {
   value = [for name, vnic in data.oci_core_vnic.app_vnic : vnic.public_ip_address]
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -15,10 +15,15 @@ terraform {
       source  = "cloudflare/cloudflare"
       version = "~> 3.15"
     }
+    github = {
+      source  = "integrations/github"
+      version = "~> 4.0"
+    }
 
   }
 }
 
+# OCI Provider
 provider "oci" {
   region       = var.region
   tenancy_ocid = var.oci_tenancy_ocid
@@ -32,10 +37,15 @@ data "oci_identity_availability_domain" "ad" {
   ad_number      = 1
 }
 
+# Cloudflare Provider
 provider "cloudflare" {
   api_token = var.cloudflare_api_token
 }
 
+# Github Provider
+provider "github" {
+  token = var.github_token
+}
 
 # SSH Key for deployer user
 resource "tls_private_key" "deployer" {
@@ -65,3 +75,4 @@ output "fqdn" {
 output "image_ocid" {
   value = lookup(data.oci_core_images.oracle_linux.images[0], "id")
 }
+

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -21,7 +21,7 @@ cloudflare_api_token = "..."
 cloudflare_zone = "example.com"
 
 
-# Cloudflare config
+# GitHub config
 # ----------------------------------------------------------------------------
 github_repository = "cloud-vault"
 github_token      = ""

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -21,6 +21,12 @@ cloudflare_api_token = "..."
 cloudflare_zone      = "example.com"
 
 
+# Cloudflare config
+# ----------------------------------------------------------------------------
+github_repository = "cloud-vault"
+github_token = ""
+
+
 # Host config
 # ----------------------------------------------------------------------------
 

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -33,13 +33,8 @@ deployer_username = "deployer"
 # Username for the sudo-enabled admin user
 admin_username = "admin"
 
-# SSH public key used for the 'admin' account on the instance.
-# This account will have sudo privileges without requiring a password
-admin_public_key = "ssh-ed25519 AAAAC..."
-
-# SSH public key used for the 'deployer' account on the instance
-# This account will have the ability to administer docker
-deployer_public_key = "ssh-rsa AAAAB..."
+# User-provided SSH public key. Will be used for both the 'admin' and 'deployer' accounts
+admin_ssh_public_key = "ssh-ed25519 AAAAC..."
 
 
 # Instance config

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -18,13 +18,13 @@ EOF
 cloudflare_api_token = "..."
 
 # Zone where DNS records will be created
-cloudflare_zone      = "example.com"
+cloudflare_zone = "example.com"
 
 
 # Cloudflare config
 # ----------------------------------------------------------------------------
 github_repository = "cloud-vault"
-github_token = ""
+github_token      = ""
 
 
 # Host config

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -31,6 +31,17 @@ variable "cloudflare_zone" {
   type = string
 }
 
+# GitHub config
+# ----------------------------------------------------------------------------
+
+variable "github_repository" {
+  type = string
+}
+
+variable "github_token" {
+  type = string
+}
+
 # Host config
 # ----------------------------------------------------------------------------
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -49,11 +49,7 @@ variable "admin_username" {
   default = "admin"
 }
 
-variable "admin_public_key" {
-  type = string
-}
-
-variable "deployer_public_key" {
+variable "admin_ssh_public_key" {
   type = string
 }
 


### PR DESCRIPTION
This writes certain values directly to GitHub action secrets instead of requiring the actions to read from Terraform Cloud.

TODO: Test on a deploy branch before merging